### PR TITLE
feat: /filteredWords endpoint to get words filtered by any param, no Auth

### DIFF
--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -156,6 +156,31 @@ paths:
             application/json:
               schema:
                   $ref: "#/components/schemas/Word"
+  /filteredWords:
+    parameters:
+      - name: filter
+        in: query
+        required: true
+        description: Filter by word fields. It should be a stringified object which meet MongoDB Query object conditions.<br>
+          Get all words starting from 'agr'(for example, "agree"):<pre>{"word":{"$regex":"^agr","$options":"i"}}</pre><br>
+        schema:
+          type: string
+    get:
+      tags:
+        - FilteredWords
+      security:
+        []
+      summary: Get filtered words
+      description: Gets filtered words
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Word"
   /users:
     post:
       tags:

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ const userRouter = require('./resources/users/user.router');
 const userTokenRouter = require('./resources/token/token.router');
 const userWordsRouter = require('./resources/userWords/userWord.router');
 const aggregatedWordsRouter = require('./resources/aggregatedWords/aggregatedWord.router');
+const filteredWordsRouter = require('./resources/filteredWords/filteredWord.router');
 const statisticRouter = require('./resources/statistics/statistic.router');
 const settingRouter = require('./resources/settings/setting.router');
 const errorHandler = require('./errors/errorHandler');
@@ -54,6 +55,8 @@ app.use(
 );
 
 app.use('/words', wordRouter);
+
+app.use('/filteredWords', filteredWordsRouter);
 
 app.use('/signin', signinRouter);
 

--- a/src/resources/authentication/checkAuthentication.js
+++ b/src/resources/authentication/checkAuthentication.js
@@ -8,7 +8,7 @@ const { AUTHORIZATION_ERROR } = require('../../errors/appErrors');
 const ALLOWED_PATHS = ['/signin', '/signup'];
 const DOC_PATH_REGEX = /^\/doc\/?$/;
 const DOC_PATH_RESOURCES_REGEX = /^\/doc\/.+$/;
-const WORDS_PATH_REGEX = /^\/words.*$/;
+const WORDS_PATH_REGEX = /^\/(words)|(filteredWords).*$/;
 const USERS_PATH = '/users';
 
 function isOpenPath(path) {

--- a/src/resources/filteredWords/filteredWord.db.repository.js
+++ b/src/resources/filteredWords/filteredWord.db.repository.js
@@ -1,0 +1,7 @@
+const Word = require('../words/word.model');
+
+const getAll = async filter => {
+  return Word.find(filter);
+};
+
+module.exports = { getAll };

--- a/src/resources/filteredWords/filteredWord.router.js
+++ b/src/resources/filteredWords/filteredWord.router.js
@@ -1,0 +1,11 @@
+const { OK } = require('http-status-codes');
+const router = require('express').Router();
+const filteredWordsService = require('./filteredWord.service');
+
+router.route('/').get(async (req, res) => {
+  const filter = req.query.filter ? JSON.parse(req.query.filter) : null;
+  const words = await filteredWordsService.getAll(filter);
+  res.status(OK).send(words.map(word => word.toResponse()));
+});
+
+module.exports = router;

--- a/src/resources/filteredWords/filteredWord.service.js
+++ b/src/resources/filteredWords/filteredWord.service.js
@@ -1,0 +1,5 @@
+const filteredWordRepo = require('./filteredWord.db.repository');
+
+const getAll = async filter => filteredWordRepo.getAll(filter);
+
+module.exports = { getAll };


### PR DESCRIPTION
/filteredWords endpoint to get words filtered by any param, with no authentication required
It can be used with any Mongo query param: https://www.mongodb.com/docs/manual/reference/operator/query/
examples: 
1) all word on page5 group 5: {"$and":[{"group": 5, "page": 5}]}
2) all words starting from 'ag': {"word": { "$regex": "^ag", "$options": "i" }}

Doc on '/doc/#/FilteredWords/get_filteredWords' path is added.
Screenshot:

![SwaggerScreenshot](https://user-images.githubusercontent.com/7703384/190008810-ec88e196-0500-41d7-8ecf-fb1f05508389.png)
